### PR TITLE
1.2.1 一定の条件で二重に改行される問題を修正

### DIFF
--- a/src/codes/AutoLineBreak/DarkPlasma_AutoLineBreak.js
+++ b/src/codes/AutoLineBreak/DarkPlasma_AutoLineBreak.js
@@ -23,7 +23,10 @@ const _Window_Base_processCharacter = Window_Base.prototype.processCharacter;
 Window_Base.prototype.processCharacter = function (textState) {
   if (this.shouldLineBreakHere(textState)) {
     this.flushTextState(textState);
-    this.processNewLine(textState);
+    //二重改行を防止
+    if(textState.text[textState.index]!=="\n"){
+      this.processNewLine(textState);
+    }
     /**
      * 改ページが必要になったら次の文字は処理しない
      */


### PR DESCRIPTION
ウィンドウ幅ギリギリの文字列を描画しようとした際に、改行によって空白の行が生じる。
![editor](https://user-images.githubusercontent.com/1804790/163893416-393f1313-afd6-430e-b52b-5fd740b3ef3d.jpg)
![screenshot](https://user-images.githubusercontent.com/1804790/163893439-28683b5b-ae2a-43dd-8cd2-c1f8bad691c9.jpg)

